### PR TITLE
Refactor initializer container lookups into an instanceIntializer

### DIFF
--- a/app/initializers/key-responder.js
+++ b/app/initializers/key-responder.js
@@ -6,48 +6,5 @@ export default {
   initialize: function(container, application) {
     application.inject('view', 'keyResponder', 'key-responder:main');
     application.inject('component', 'keyResponder', 'key-responder:main');
-
-    //TextField/TextArea are currently uninjectable, so we're going to hack our
-    //way in
-    Ember.TextSupport.reopen({
-      keyResponder: Ember.computed(function() {
-        return this.container.lookup('key-responder:main');
-      }).readOnly()
-    });
-
-    // Set up a handler on the document for keyboard events that are not
-    // handled by Ember's event dispatcher.
-    Ember.$(document).on('keyup.outside_ember_event_delegation', null,
-                         function(event) {
-
-      if (Ember.$(event.target).closest('.ember-view').length === 0) {
-        var keyResponder = container.lookup('key-responder:main');
-        var currentKeyResponder = keyResponder.get('current');
-        if (currentKeyResponder && currentKeyResponder.get('isVisible')) {
-          return currentKeyResponder.respondToKeyEvent(event, currentKeyResponder);
-        }
-      }
-
-      return true;
-    });
-
-    // Set up a handler on the ApplicationView for keyboard events that were
-    // not handled by the current KeyResponder yet
-    container.lookupFactory('view:application').reopen({
-      delegateToKeyResponder: Ember.on('keyUp', function(event) {
-        var currentKeyResponder = this.get('keyResponder.current');
-        if (currentKeyResponder && currentKeyResponder.get('isVisible')) {
-          // check to see if the event target is the keyResponder or the
-          // keyResponders parents.  if so, no need to dispatch as it has
-          // already had a chance to handle this event.
-          var id =  '#' + currentKeyResponder.get('elementId');
-          if (Ember.$(event.target).closest(id).length === 1) {
-            return true;
-          }
-          return currentKeyResponder.respondToKeyEvent(event, currentKeyResponder);
-        }
-        return true;
-      })
-    });
   }
 };

--- a/app/initializers/key-responder.js
+++ b/app/initializers/key-responder.js
@@ -1,9 +1,29 @@
 import Ember from 'ember';
+import keyResponderInstanceInitializer from '../instance-initializers/key-responder';
+
+var EMBER_VERSION_REGEX = /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:(?:\-(alpha|beta)\.([0-9]+)(?:\.([0-9]+))?)?)?(?:\+(canary))?(?:\.([0-9abcdef]+))?$/;
+/**
+ * VERSION_INFO[i] is as follows:
+ *
+ * 0  complete version string
+ * 1  major version
+ * 2  minor version
+ * 3  trivial version
+ * 4  pre-release type (optional: "alpha" or "beta" or undefined for stable releases)
+ * 5  pre-release version (optional)
+ * 6  pre-release sub-version (optional)
+ * 7  canary (optional: "canary", or undefined for stable releases)
+ * 8  SHA (optional)
+ */
+var VERSION_INFO = EMBER_VERSION_REGEX.exec(Ember.VERSION);
+
 
 export default {
   name: 'ember-key-responder',
 
-  initialize: function(container, application) {
+  initialize(registry, application) {
+    var isPre110 = parseInt(versionInfo[1], 10) < 2 && parseInt(versionInfo[2], 10) < 11;
+
     application.inject('view', 'keyResponder', 'key-responder:main');
     application.inject('component', 'keyResponder', 'key-responder:main');
 
@@ -11,8 +31,28 @@ export default {
     //way in
     Ember.TextSupport.reopen({
       keyResponder: Ember.computed(function() {
-        return this.container.lookup('key-responder:main');
+        return this.registry.lookup('key-responder:main');
       }).readOnly()
     });
+
+    // Set up a handler on the document for keyboard events that are not
+    // handled by Ember's event dispatcher.
+    Ember.$(document).on('keyup.outside_ember_event_delegation', null, event => {
+
+      if (Ember.$(event.target).closest('.ember-view').length === 0) {
+        var keyResponder = instance.container.lookup('key-responder:main');
+        var currentKeyResponder = keyResponder.get('current');
+        if (currentKeyResponder && currentKeyResponder.get('isVisible')) {
+          return currentKeyResponder.respondToKeyEvent(event, currentKeyResponder);
+        }
+      }
+
+      return true;
+    });
+
+    if (isPre110) {
+      // For versions before 1.11.0, we have to call the instanceInitializer
+      keyResponderInstanceInitializer.initializer(registry, application);
+    }
   }
 };

--- a/app/initializers/key-responder.js
+++ b/app/initializers/key-responder.js
@@ -6,5 +6,13 @@ export default {
   initialize: function(container, application) {
     application.inject('view', 'keyResponder', 'key-responder:main');
     application.inject('component', 'keyResponder', 'key-responder:main');
+
+    //TextField/TextArea are currently uninjectable, so we're going to hack our
+    //way in
+    Ember.TextSupport.reopen({
+      keyResponder: Ember.computed(function() {
+        return this.container.lookup('key-responder:main');
+      }).readOnly()
+    });
   }
 };

--- a/app/instance-initializers/key-responder.js
+++ b/app/instance-initializers/key-responder.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+
+export default {
+  name: 'ember-key-responder-instance',
+
+  initialize: function(instance) {
+
+    //TextField/TextArea are currently uninjectable, so we're going to hack our
+    //way in
+    Ember.TextSupport.reopen({
+      keyResponder: Ember.computed(function() {
+        return this.container.lookup('key-responder:main');
+      }).readOnly()
+    });
+
+    // Set up a handler on the document for keyboard events that are not
+    // handled by Ember's event dispatcher.
+    Ember.$(document).on('keyup.outside_ember_event_delegation', null,
+                         function(event) {
+
+      if (Ember.$(event.target).closest('.ember-view').length === 0) {
+        var keyResponder = instance.container.lookup('key-responder:main');
+        var currentKeyResponder = keyResponder.get('current');
+        if (currentKeyResponder && currentKeyResponder.get('isVisible')) {
+          return currentKeyResponder.respondToKeyEvent(event, currentKeyResponder);
+        }
+      }
+
+      return true;
+    });
+
+    // Set up a handler on the ApplicationView for keyboard events that were
+    // not handled by the current KeyResponder yet
+    instance.container.lookupFactory('view:application').reopen({
+      delegateToKeyResponder: Ember.on('keyUp', function(event) {
+        var currentKeyResponder = this.get('keyResponder.current');
+        if (currentKeyResponder && currentKeyResponder.get('isVisible')) {
+          // check to see if the event target is the keyResponder or the
+          // keyResponders parents.  if so, no need to dispatch as it has
+          // already had a chance to handle this event.
+          var id =  '#' + currentKeyResponder.get('elementId');
+          if (Ember.$(event.target).closest(id).length === 1) {
+            return true;
+          }
+          return currentKeyResponder.respondToKeyEvent(event, currentKeyResponder);
+        }
+        return true;
+      })
+    });
+  }
+};

--- a/app/instance-initializers/key-responder.js
+++ b/app/instance-initializers/key-responder.js
@@ -5,14 +5,6 @@ export default {
 
   initialize: function(instance) {
 
-    //TextField/TextArea are currently uninjectable, so we're going to hack our
-    //way in
-    Ember.TextSupport.reopen({
-      keyResponder: Ember.computed(function() {
-        return this.container.lookup('key-responder:main');
-      }).readOnly()
-    });
-
     // Set up a handler on the document for keyboard events that are not
     // handled by Ember's event dispatcher.
     Ember.$(document).on('keyup.outside_ember_event_delegation', null,

--- a/app/instance-initializers/key-responder.js
+++ b/app/instance-initializers/key-responder.js
@@ -3,23 +3,7 @@ import Ember from 'ember';
 export default {
   name: 'ember-key-responder-instance',
 
-  initialize: function(instance) {
-
-    // Set up a handler on the document for keyboard events that are not
-    // handled by Ember's event dispatcher.
-    Ember.$(document).on('keyup.outside_ember_event_delegation', null,
-                         function(event) {
-
-      if (Ember.$(event.target).closest('.ember-view').length === 0) {
-        var keyResponder = instance.container.lookup('key-responder:main');
-        var currentKeyResponder = keyResponder.get('current');
-        if (currentKeyResponder && currentKeyResponder.get('isVisible')) {
-          return currentKeyResponder.respondToKeyEvent(event, currentKeyResponder);
-        }
-      }
-
-      return true;
-    });
+  initialize(instance) {
 
     // Set up a handler on the ApplicationView for keyboard events that were
     // not handled by the current KeyResponder yet

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.2.8",
     "ember-qunit-notifications": "0.0.7",
     "qunit": "~1.17.1"


### PR DESCRIPTION
This addresses an ember-1.11 deprecation warning
http://emberjs.com/deprecations/v1.x/#toc_access-to-instances-in-initializers