### PR TITLE
Test coverage, Ember 2.0 compatibility

### DIFF
--- a/app/initializers/key-responder.js
+++ b/app/initializers/key-responder.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import keyResponderInstanceInitializer from '../instance-initializers/key-responder';
 
-var EMBER_VERSION_REGEX = /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:(?:\-(alpha|beta)\.([0-9]+)(?:\.([0-9]+))?)?)?(?:\+(canary))?(?:\.([0-9abcdef]+))?$/;
+var EMBER_VERSION_REGEX = /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:(?:\-(alpha|beta)\.([0-9]+)(?:\.([0-9]+))?)?)?(?:\+(canary))?(?:\.([0-9abcdef]+))?(?:\-([A-Za-z0-9\.\-]+))?(?:\+([A-Za-z0-9\.\-]+))?$/;
+
 /**
  * VERSION_INFO[i] is as follows:
  *
@@ -22,7 +23,8 @@ export default {
   name: 'ember-key-responder',
 
   initialize(registry, application) {
-    var isPre110 = parseInt(versionInfo[1], 10) < 2 && parseInt(versionInfo[2], 10) < 11;
+    var isPre111 = parseInt(VERSION_INFO[1], 10) < 2 && parseInt(VERSION_INFO[2], 10) < 12;
+    const container = application.__container__;
 
     application.inject('view', 'keyResponder', 'key-responder:main');
     application.inject('component', 'keyResponder', 'key-responder:main');
@@ -40,7 +42,7 @@ export default {
     Ember.$(document).on('keyup.outside_ember_event_delegation', null, event => {
 
       if (Ember.$(event.target).closest('.ember-view').length === 0) {
-        var keyResponder = instance.container.lookup('key-responder:main');
+        var keyResponder = container.lookup('key-responder:main');
         var currentKeyResponder = keyResponder.get('current');
         if (currentKeyResponder && currentKeyResponder.get('isVisible')) {
           return currentKeyResponder.respondToKeyEvent(event, currentKeyResponder);
@@ -50,9 +52,9 @@ export default {
       return true;
     });
 
-    if (isPre110) {
-      // For versions before 1.11.0, we have to call the instanceInitializer
-      keyResponderInstanceInitializer.initializer(registry, application);
+    if (isPre111) {
+      // For versions before 1.12.0, we have to call the instanceInitializer
+      keyResponderInstanceInitializer.initialize(registry, application);
     }
   }
 };

--- a/app/instance-initializers/key-responder.js
+++ b/app/instance-initializers/key-responder.js
@@ -5,7 +5,7 @@ export default {
 
   initialize(container, instance) {
     // Handle 1.12.x case, where signature is
-    //  initialize(container) {...}
+    //  initialize(instance) {...}
     if (typeof instance === 'undefined') {
       instance = container;
       container = instance.container;

--- a/app/instance-initializers/key-responder.js
+++ b/app/instance-initializers/key-responder.js
@@ -3,11 +3,16 @@ import Ember from 'ember';
 export default {
   name: 'ember-key-responder-instance',
 
-  initialize(instance) {
-
+  initialize(container, instance) {
+    // Handle 1.12.x case, where signature is
+    //  initialize(container) {...}
+    if (typeof instance === 'undefined') {
+      instance = container;
+      container = instance.container;
+    }
     // Set up a handler on the ApplicationView for keyboard events that were
     // not handled by the current KeyResponder yet
-    instance.container.lookupFactory('view:application').reopen({
+    container.lookupFactory('view:application').reopen({
       delegateToKeyResponder: Ember.on('keyUp', function(event) {
         var currentKeyResponder = this.get('keyResponder.current');
         if (currentKeyResponder && currentKeyResponder.get('isVisible')) {

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "jquery": "^1.11.1",
     "ember": "1.10.0",
-    "ember-data": "1.0.0-beta.15",
     "ember-resolver": "~0.1.12",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,19 +8,23 @@ module.exports = {
     {
       name: 'ember-1.10',
       dependencies: {
-        ember: '~1.10.0'
+        ember: '~1.10.0',
+        'ember-load-initializers': 'ember-cli/ember-load-initializers#0.0.2'
       },
       resolutions: {
-        ember: '~1.10.0'
+        ember: '~1.10.0',
+        'ember-load-initializers': 'ember-cli/ember-load-initializers#0.0.2'
       }
     },
     {
       name: 'ember-1.11',
       dependencies: {
-        ember: '~1.11.0'
+        ember: '~1.11.0',
+        'ember-load-initializers': 'ember-cli/ember-load-initializers#0.0.2'
       },
       resolutions: {
-        ember: '~1.11.0'
+        ember: '~1.11.0',
+        'ember-load-initializers': 'ember-cli/ember-load-initializers#0.0.2'
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.9",
     "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
+    "ember-legacy-views": "0.2.0",
     "ember-try": "0.0.4",
     "rsvp": "^3.0.14"
   },

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -6,7 +6,7 @@
 <div id="events" style="float:left; width: 300px; height: 300px; overflow-y: scroll">
   event stream ({{events.length}})
   <ul>
-    {{#each event in events}}
+    {{#each events as |event|}}
       <li>{{event.viewName}} - {{event.eventName}}</li>
     {{/each}}
   </ul>

--- a/tests/dummy/app/templates/components/key-responder-info.hbs
+++ b/tests/dummy/app/templates/components/key-responder-info.hbs
@@ -2,7 +2,7 @@ KeyResponder stack active:
 {{keyResponder.isActive}}
 {{input type="checkbox" checked=keyResponder.isActive}}
 <ol>
-  {{#each keyResponder}}
-    <li>{{name}} - {{this}}</li>
+  {{#each keyResponder as |resp|}}
+    <li>{{resp.name}} - {{resp}}</li>
   {{/each}}
   </ol>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -12,7 +12,9 @@ module.exports = function(environment) {
         // e.g. 'with-controller': true
       }
     },
-
+    contentSecurityPolicy: {
+      'style-src': "'self' 'unsafe-inline'"
+    },
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
@@ -26,7 +28,6 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
   }
-
   if (environment === 'test') {
     // Testem prefers this...
     ENV.baseURL = '/';

--- a/tests/integration/demo-test.js
+++ b/tests/integration/demo-test.js
@@ -1,0 +1,54 @@
+import Ember from 'ember';
+
+import startApp from '../../tests/helpers/start-app';
+import { module, test } from 'qunit';
+
+var App;
+
+module('Acceptance - Demo page', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+function pressTab() {
+  let e = Ember.$.Event("keyup", {keyCode: 9, which: 9});
+  Ember.$('body').trigger(e);
+}
+
+test('Load the demo page', function(assert) {
+  visit('/');
+
+  andThen(function () {
+    let eventLiArray = find('#events ul li');
+    assert.equal(eventLiArray.length, 0, 'No events fired yet');
+
+    const componentC = find('.component-c');
+    assert.equal(componentC.length, 0, 'Component c is initially inactive');
+
+    pressTab();
+
+    eventLiArray = find('#events ul li');
+    assert.equal(eventLiArray.length, 1, '1 event fired');
+    assert.equal(eventLiArray[0].innerText, 'a - insertTab', 'correct event name and key responder');
+  });
+
+  click('#example label:first-child .ember-checkbox');
+
+  andThen(function () {
+    const componentC = find('.component-c');
+    assert.ok(componentC, 'Component c is active, after user activation');
+
+    pressTab();
+    pressTab();
+
+    let eventLiArray = find('#events ul li');
+    assert.equal(eventLiArray.length, 3, '3 events fired');
+
+    eventLiArray = find('#events ul li');
+    assert.equal(eventLiArray[1].innerText, 'c - insertTab', 'correct event name and key responder');
+  });
+});


### PR DESCRIPTION
I added an acceptance test to confirm that the initializer/instanceInitializer installation was happening properly, and it turns out that there are some subtle differences between how this works across several versions of ember.

* 1.10 - pure (non instance) initializer
* 1.11 - pure (non instance) initializer
* 1.12 - instance initializer supported. expected signature: ```function: initialize(instance) {...} ```
* 1.13 - instance initializer supported. expected signature: ```function: initialize(container, instance) {...} ```
* 2.0 - instance initializer supported. expected signature: ```function: initialize(container, instance) {...} ```, needed to add legacy views support

