### PR TITLE
Align with ember 2.1 container reform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,12 @@ env:
   - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
+  - ALLOW_DEPRECATIONS=true EMBER_TRY_SCENARIO=ember-canary
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: ALLOW_DEPRECATIONS=true EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH

--- a/app/initializers/key-responder.js
+++ b/app/initializers/key-responder.js
@@ -22,7 +22,10 @@ var VERSION_INFO = EMBER_VERSION_REGEX.exec(Ember.VERSION);
 export default {
   name: 'ember-key-responder',
 
-  initialize(registry, application) {
+  initialize() {
+    const application = arguments[1] || arguments[0];
+    const registry = !!arguments[1] ? arguments[0] : application.registry;
+    
     var isPre111 = parseInt(VERSION_INFO[1], 10) < 2 && parseInt(VERSION_INFO[2], 10) < 12;
     const container = application.__container__;
 

--- a/app/instance-initializers/key-responder.js
+++ b/app/instance-initializers/key-responder.js
@@ -1,32 +1,39 @@
 import Ember from 'ember';
 
+const { Mixin, on } = Ember;
+
+const ApplicationViewMixin = Mixin.create({
+  delegateToKeyResponder: on('keyUp', function(event) {
+    var currentKeyResponder = this.get('keyResponder.current');
+    if (currentKeyResponder && currentKeyResponder.get('isVisible')) {
+      // check to see if the event target is the keyResponder or the
+      // keyResponders parents.  if so, no need to dispatch as it has
+      // already had a chance to handle this event.
+      var id =  '#' + currentKeyResponder.get('elementId');
+      if (Ember.$(event.target).closest(id).length === 1) {
+        return true;
+      }
+      return currentKeyResponder.respondToKeyEvent(event, currentKeyResponder);
+    }
+    return true;
+  })
+});
+
 export default {
   name: 'ember-key-responder-instance',
 
-  initialize(container, instance) {
+  initialize() {
     // Handle 1.12.x case, where signature is
     //  initialize(instance) {...}
-    if (typeof instance === 'undefined') {
-      instance = container;
-      container = instance.container;
-    }
+    const instance = arguments[1] || arguments[0];
+    const container = !!arguments[1] ? arguments[0] : instance.container;
+
     // Set up a handler on the ApplicationView for keyboard events that were
     // not handled by the current KeyResponder yet
-    container.lookupFactory('view:application').reopen({
-      delegateToKeyResponder: Ember.on('keyUp', function(event) {
-        var currentKeyResponder = this.get('keyResponder.current');
-        if (currentKeyResponder && currentKeyResponder.get('isVisible')) {
-          // check to see if the event target is the keyResponder or the
-          // keyResponders parents.  if so, no need to dispatch as it has
-          // already had a chance to handle this event.
-          var id =  '#' + currentKeyResponder.get('elementId');
-          if (Ember.$(event.target).closest(id).length === 1) {
-            return true;
-          }
-          return currentKeyResponder.respondToKeyEvent(event, currentKeyResponder);
-        }
-        return true;
-      })
-    });
+    let ApplicationView = container.lookupFactory ?
+      container.lookupFactory('view:application') :
+      instance.resolveRegistration('view:application');
+    
+    ApplicationView = ApplicationView.extend(ApplicationViewMixin);
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.6",
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.18",
+    "ember-resolver": "~0.1.20",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-key-responder",
   "description": "A component-oriented approach to keyboard shortcuts for Ember, inspired by Cocoa's KeyResponder.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -33,7 +33,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
-    "ember-export-application-global": "^1.0.3",
+    "ember-export-application-global": "^1.0.4",
     "ember-legacy-views": "0.2.0",
     "ember-try": "0.0.6",
     "rsvp": "^3.0.14"

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -29,6 +29,8 @@ module.exports = function(environment) {
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
   }
   if (environment === 'test') {
+    ENV.EmberENV.RAISE_ON_DEPRECATION = !process.env['ALLOW_DEPRECATIONS'];
+
     // Testem prefers this...
     ENV.baseURL = '/';
     ENV.locationType = 'none';


### PR DESCRIPTION
This may be a superset of #22 

Fixes #17 

- Align with new container reform, using `resolveRegistration` instead of `lookupFactory`
- Modify ApplicationView via a Mixin, rather than reopening, to ensure it only happens once
- Error in CI (on all except canary channel) if deprecation warnings are thrown as part of test suite
- Bumped version from `0.4.0` to `0.4.1` 